### PR TITLE
refactor: centralize database schema setup

### DIFF
--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -1,14 +1,13 @@
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 from fastapi.security import OAuth2PasswordRequestForm
-from ..db import get_db, Base, engine
+from ..db import get_db
 from ..models import User
 from ..schemas import RegisterRequest, TokenResponse, MeResponse
 from ..auth import hash_password, authenticate, create_access_token, get_current_user
 from email_validator import validate_email, EmailNotValidError
 
 router = APIRouter()
-Base.metadata.create_all(bind=engine)
 
 @router.post("/auth/register")
 def register(data: RegisterRequest, db: Session = Depends(get_db)):

--- a/app/routes/listings.py
+++ b/app/routes/listings.py
@@ -2,13 +2,12 @@ from fastapi import APIRouter, Depends, HTTPException, UploadFile, File
 from sqlalchemy.orm import Session
 from typing import List, Optional
 import os, shutil
-from ..db import get_db, Base, engine
+from ..db import get_db
 from ..models import Listing, ListingType, User, Message
 from ..schemas import ListingIn, ListingOut, MessageIn, MessageOut
 from ..auth import get_current_user, admin_required
 
 router = APIRouter()
-Base.metadata.create_all(bind=engine)
 
 def to_out(l: Listing) -> ListingOut:
     return ListingOut(

--- a/app/seed.py
+++ b/app/seed.py
@@ -1,11 +1,10 @@
 import os
 from sqlalchemy.orm import Session
-from .db import SessionLocal, Base, engine
+from .db import SessionLocal
 from .models import User, Listing, ListingType
 from .auth import hash_password
 
 def run():
-    Base.metadata.create_all(bind=engine)
     db: Session = SessionLocal()
     try:
         admin_email = os.getenv("ADMIN_EMAIL", "admin@falcontrade.org")


### PR DESCRIPTION
## Summary
- remove redundant `Base.metadata.create_all` calls from `auth` and `listings` routes
- avoid schema initialization inside `seed` script
- rely on a single schema initialization in `main.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c843be0408325966cda20473c5e37