### PR TITLE
Use default_factory for mutable schema fields

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -18,7 +18,7 @@ class ListingBase(BaseModel):
     type: str
     category: str
     title: str
-    details: Dict[str, Any] = {}
+    details: Dict[str, Any] = Field(default_factory=dict)
     quantity: str = ""
     incoterm: str = ""
     country: str = ""


### PR DESCRIPTION
## Summary
- replace empty dict default with `Field(default_factory=dict)` in Listing schema
- audit other Pydantic schemas to ensure no mutable defaults remain

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c85f2b84c8325915176c606fd1f64