### PR TITLE
Add password validation and login rate limiting

### DIFF
--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy.orm import Session
 from fastapi.security import OAuth2PasswordRequestForm
 from ..db import get_db
@@ -6,6 +6,11 @@ from ..models import User
 from ..schemas import RegisterRequest, TokenResponse, MeResponse
 from ..auth import hash_password, authenticate, create_access_token, get_current_user
 from email_validator import validate_email, EmailNotValidError
+from time import time
+
+login_attempts: dict[str, list[float]] = {}
+ATTEMPT_WINDOW = 60
+MAX_ATTEMPTS = 5
 
 router = APIRouter()
 
@@ -23,7 +28,21 @@ def register(data: RegisterRequest, db: Session = Depends(get_db)):
     return {"ok": True}
 
 @router.post("/auth/login", response_model=TokenResponse)
-def login(form: OAuth2PasswordRequestForm = Depends(), db: Session = Depends(get_db)):
+def login(
+    request: Request,
+    form: OAuth2PasswordRequestForm = Depends(),
+    db: Session = Depends(get_db),
+):
+    ip = request.client.host
+    now = time()
+    attempts = [t for t in login_attempts.get(ip, []) if now - t < ATTEMPT_WINDOW]
+    if len(attempts) >= MAX_ATTEMPTS:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Too many login attempts",
+        )
+    attempts.append(now)
+    login_attempts[ip] = attempts
     user = authenticate(db, form.username, form.password)
     if not user:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,10 +1,21 @@
-from pydantic import BaseModel, EmailStr, Field
+from pydantic import BaseModel, EmailStr, Field, field_validator
 from typing import Dict, Any
 from datetime import datetime
+import re
 
 class RegisterRequest(BaseModel):
     email: EmailStr
-    password: str = Field(min_length=6)
+    password: str = Field(min_length=8)
+
+    @field_validator("password")
+    @classmethod
+    def validate_password(cls, value: str) -> str:
+        pattern = re.compile(r"^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,}$")
+        if not pattern.match(value):
+            raise ValueError(
+                "Password must contain at least one uppercase letter, one lowercase letter, one number, and one special character"
+            )
+        return value
 
 class TokenResponse(BaseModel):
     access_token: str


### PR DESCRIPTION
## Summary
- enforce strong password requirements during registration
- throttle excessive login attempts with simple in-memory limiter

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c85f8a99883259cd914190c1ccb14