### PR TITLE
Fix stripe dependency for render deployment

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ passlib[bcrypt]==1.7.4
 bcrypt==4.1.2
 email-validator==2.2.0
 python-dotenv==1.0.1
-stripe==5.9.0
+stripe==12.4.0


### PR DESCRIPTION
## Summary
- pin stripe to version 12.4.0 to resolve missing distribution errors during deploy

## Testing
- `python -m pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c9ab14e188325965a3de7d6f21bec